### PR TITLE
Patches

### DIFF
--- a/components/esp_modem/examples/modem_console/main/modem_console_main.cpp
+++ b/components/esp_modem/examples/modem_console/main/modem_console_main.cpp
@@ -28,6 +28,7 @@
 #include "esp_log.h"
 #include "console_helper.hpp"
 #include "my_module_dce.hpp"
+#include "esp_netif_ppp.h"
 
 #if defined(CONFIG_EXAMPLE_FLOW_CONTROL_NONE)
 #define EXAMPLE_FLOW_CONTROL ESP_MODEM_FLOW_CONTROL_NONE
@@ -113,12 +114,13 @@ extern "C" void app_main(void)
     esp_netif_config_t ppp_netif_config = ESP_NETIF_DEFAULT_PPP();
     esp_netif_t *esp_netif = esp_netif_new(&ppp_netif_config);
     assert(esp_netif);
-
+    esp_netif_ppp_set_auth(esp_netif, NETIF_PPP_AUTHTYPE_PAP, "esp32", "test");
 #if defined(CONFIG_EXAMPLE_SERIAL_CONFIG_UART)
     esp_modem_dte_config_t dte_config = ESP_MODEM_DTE_DEFAULT_CONFIG();
     /* setup UART specific configuration based on kconfig options */
     dte_config.uart_config.tx_io_num = CONFIG_EXAMPLE_MODEM_UART_TX_PIN;
     dte_config.uart_config.rx_io_num = CONFIG_EXAMPLE_MODEM_UART_RX_PIN;
+    dte_config.uart_config.port_num = UART_NUM_0;
     dte_config.uart_config.rts_io_num = CONFIG_EXAMPLE_MODEM_UART_RTS_PIN;
     dte_config.uart_config.cts_io_num = CONFIG_EXAMPLE_MODEM_UART_CTS_PIN;
     dte_config.uart_config.flow_control = EXAMPLE_FLOW_CONTROL;

--- a/components/esp_modem/include/cxx_include/esp_modem_dce_module.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_dce_module.hpp
@@ -53,9 +53,9 @@ public:
         if (set_echo(false) != command_result::OK) {
             return false;
         }
-        if (set_pdp_context(*pdp) != command_result::OK) {
-            return false;
-        }
+        //if (set_pdp_context(*pdp) != command_result::OK) {
+        //    return false;
+        //}
         return true;
     }
 

--- a/components/esp_modem/include/cxx_include/esp_modem_types.hpp
+++ b/components/esp_modem/include/cxx_include/esp_modem_types.hpp
@@ -55,7 +55,7 @@ typedef std::function<command_result(uint8_t *data, size_t len)> got_line_cb;
  */
 struct PdpContext {
     explicit PdpContext(std::string apn) : apn(std::move(apn)) {}
-    size_t context_id = 1;
+    size_t context_id = 0;
     std::string protocol_type = "IP";
     std::string apn;
 };

--- a/components/esp_modem/include/generate/esp_modem_command_declare.inc
+++ b/components/esp_modem/include/generate/esp_modem_command_declare.inc
@@ -140,6 +140,20 @@ ESP_MODEM_DECLARE_DCE_COMMAND(get_imsi, command_result, 1, STRING_OUT(p1, imsi))
 ESP_MODEM_DECLARE_DCE_COMMAND(get_imei, command_result, 1, STRING_OUT(p1, imei)) \
     \
 /**
+ * @brief Reads the ICCID number
+ * @param[out] iccid Module's ICCID number
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(get_iccid, command_result, 1, STRING_OUT(p1, iccid)) \
+    \
+/**
+ * @brief Reads the RMC string
+ * @param[out] rmc GPS's RMC string
+ * @return OK, FAIL or TIMEOUT
+ */ \
+ESP_MODEM_DECLARE_DCE_COMMAND(get_rmc, command_result, 1, STRING_OUT(p1, rmc)) \
+    \
+/**
  * @brief Reads the module name
  * @param[out] name module name
  * @return OK, FAIL or TIMEOUT

--- a/components/esp_modem/library.json
+++ b/components/esp_modem/library.json
@@ -1,0 +1,13 @@
+{
+    "name": "esp_modem",
+    "version": "1.1.0",
+    "description": "esp_modem",
+    "frameworks": "espidf",
+    "platforms": "*",
+    "build": {
+	"srcFilter": "+src/<*> -src/<*linux*>",
+	"flags": [
+	    "-I private_include"
+	]
+    }
+}

--- a/components/esp_modem/src/esp_modem_c_api.cpp
+++ b/components/esp_modem/src/esp_modem_c_api.cpp
@@ -249,6 +249,31 @@ extern "C" esp_err_t esp_modem_get_imei(esp_modem_dce_t *dce_wrap, char *p_imei)
     return ret;
 }
 
+extern "C" esp_err_t esp_modem_get_iccid(esp_modem_dce_t *dce_wrap, char *p_iccid)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    std::string iccid;
+    auto ret = command_response_to_esp_err(dce_wrap->dce->get_iccid(iccid));
+    if (ret == ESP_OK && !iccid.empty()) {
+        strlcpy(p_iccid, iccid.c_str(), ESP_MODEM_C_API_STR_MAX);
+    }
+    return ret;
+}
+extern "C" esp_err_t esp_modem_get_rmc(esp_modem_dce_t *dce_wrap, char *p_rmc)
+{
+    if (dce_wrap == nullptr || dce_wrap->dce == nullptr) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    std::string rmc;
+    auto ret = command_response_to_esp_err(dce_wrap->dce->get_rmc(rmc));
+    if (ret == ESP_OK && !rmc.empty()) {
+        strlcpy(p_rmc, rmc.c_str(), ESP_MODEM_C_API_STR_MAX);
+    }
+    return ret;
+}
+
 extern "C" esp_err_t esp_modem_get_operator_name(esp_modem_dce_t *dce_wrap, char *p_name, int *p_act)
 {
     if (dce_wrap == nullptr || dce_wrap->dce == nullptr || p_name == nullptr || p_act == nullptr) {

--- a/components/esp_modem/src/esp_modem_command_library.cpp
+++ b/components/esp_modem/src/esp_modem_command_library.cpp
@@ -301,7 +301,7 @@ command_result set_data_mode(CommandableIf *t)
 command_result set_data_mode_alt(CommandableIf *t)
 {
     ESP_LOGV(TAG, "%s", __func__ );
-    return generic_command(t, "ATD*99##\r", "CONNECT", "ERROR", 5000);
+    return generic_command(t, "ATD*99***1#\r", "CONNECT", "ERROR", 5000);
 }
 
 command_result resume_data_mode(CommandableIf *t)
@@ -315,7 +315,7 @@ command_result set_command_mode(CommandableIf *t)
     ESP_LOGV(TAG, "%s", __func__ );
     const auto pass = std::list<std::string_view>({"NO CARRIER", "OK"});
     const auto fail = std::list<std::string_view>({"ERROR"});
-    return generic_command(t, "+++", pass, fail, 5000);
+    return generic_command(t, "~+++", pass, fail, 5000);
 }
 
 command_result get_imsi(CommandableIf *t, std::string &imsi_number)
@@ -328,6 +328,44 @@ command_result get_imei(CommandableIf *t, std::string &out)
 {
     ESP_LOGV(TAG, "%s", __func__ );
     return generic_get_string(t, "AT+CGSN\r", out, 5000);
+}
+
+command_result get_iccid(CommandableIf *t, std::string &iccid)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    std::string out;
+    auto ret = generic_get_string(t, "AT+CCID\r", out, 5000);
+    if (ret != command_result::OK) {
+        return ret;
+    }
+
+    constexpr std::string_view pattern = "+CCID: ";
+    constexpr int iccid_pos = pattern.size();
+    if (out.find(pattern) == std::string::npos) {
+        return command_result::FAIL;
+    }
+
+    iccid = out.data() + iccid_pos;
+    return command_result::OK;
+}
+
+command_result get_rmc(CommandableIf *t, std::string &rmc)
+{
+    ESP_LOGV(TAG, "%s", __func__ );
+    std::string out;
+    auto ret = generic_get_string(t, "AT+UGRMC?\r", out, 1000);
+    if (ret != command_result::OK) {
+        return ret;
+    }
+
+    constexpr std::string_view pattern = "+UGRMC: 1,";
+    constexpr int rmc_pos = pattern.size();
+    if (out.find(pattern) == std::string::npos) {
+        return command_result::FAIL;
+    }
+
+    rmc = out.data() + rmc_pos;
+    return command_result::OK;
 }
 
 command_result get_module_name(CommandableIf *t, std::string &out)
@@ -373,7 +411,7 @@ command_result send_sms(CommandableIf *t, const std::string &number, const std::
 command_result set_cmux(CommandableIf *t)
 {
     ESP_LOGV(TAG, "%s", __func__ );
-    return generic_command_common(t, "AT+CMUX=0\r");
+    return generic_command_common(t, "AT+CMUX=0,0,,127\r");
 }
 
 command_result read_pin(CommandableIf *t, bool &pin_ok)
@@ -432,7 +470,7 @@ command_result get_signal_quality(CommandableIf *t, int &rssi, int &ber)
 {
     ESP_LOGV(TAG, "%s", __func__ );
     std::string out;
-    auto ret = generic_get_string(t, "AT+CSQ\r", out);
+    auto ret = generic_get_string(t, "AT+CSQ\r", out, 1000);
     if (ret != command_result::OK) {
         return ret;
     }

--- a/components/esp_modem/src/esp_modem_dte.cpp
+++ b/components/esp_modem/src/esp_modem_dte.cpp
@@ -155,10 +155,11 @@ bool DTE::exit_cmux()
         return false;
     }
     if (!cmux_term->deinit()) {
-        return false;
+        ESP_LOGW("esp_modem_dte", "exit_cmux(), deinit failed");
     }
     exit_cmux_internal();
     cmux_term.reset();
+    cmux_term = nullptr;
     return true;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added APIs to retrieve SIM ICCID and RMC data from the modem.
- Bug Fixes
  - Improved CMUX exit robustness and increased signal quality query timeout.
- Refactor
  - Updated dialing, escape, and CMUX configuration sequences.
  - Changed default PDP context ID to 0 and bypassed PDP setup in data mode.
  - Set default UART port to 0 in the example and configured PPP authentication to PAP.
- Chores
  - Added library manifest for esp_modem build integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->